### PR TITLE
Refactor spinner

### DIFF
--- a/src/workbench/CenterSpinner.tsx
+++ b/src/workbench/CenterSpinner.tsx
@@ -1,0 +1,32 @@
+
+import React from 'react';
+
+import { Box, CircularProgress } from '@mui/material';
+
+import { useProgressStateStore } from './state/ProgressState';
+
+const CenterSpinner : React.FC = () => {
+
+    const activity = useProgressStateStore((state) => state.activity);
+
+    if (activity.size < 1) return null;
+
+    return (
+        <Box
+            sx={{
+                position: 'absolute',
+                top: 'calc(50% - 3rem)',
+                left: 'calc(50% - 3rem)',
+                zIndex: 999,
+                m: 0,
+                p: 0,
+            }}
+        >
+                <CircularProgress size="6rem"/>
+        </Box>
+    );
+
+}
+
+export default CenterSpinner;
+

--- a/src/workbench/Workbench.tsx
+++ b/src/workbench/Workbench.tsx
@@ -9,6 +9,7 @@ import Workspace from './Workspace.tsx';
 import { useProgressStateStore } from './state/ProgressState';
 
 import './Workbench.scss';
+
 import { SocketProvider } from './socket/SocketProvider';
 
 const Workbench : React.FC = () => {
@@ -19,53 +20,38 @@ const Workbench : React.FC = () => {
 
         <SocketProvider>
             <Box className="workbench">
-            {
-                (activity.size > 0) && 
-                <Box
-                    sx={{
-                        position: 'absolute',
-                        top: 'calc(50% - 3rem)',
-                        left: 'calc(50% - 3rem)',
-                        zIndex: 999,
-                        m: 0,
-                        p: 0,
-                    }}
-                >
-                        <CircularProgress size="6rem"/>
-                </Box>
-            }
-            {
-                (activity.size > 0) && 
-                <Box
-                    sx={{
-                        position: 'absolute',
-                        bottom: '2rem',
-                        left: '2rem',
-                        zIndex: 999,
-                        m: 0,
-                        pt: '0.8rem',
-                        pb: '0.8rem',
-                        pl: '1.2rem',
-                        pr: '1.2rem',
-                        backgroundColor: 'rgba(255, 255, 255, 0.9)',
-                        color: 'secondary',
-                        border: '1px solid #c0c080',
-                    }}
-                >
-                        {
-                            Array.from(activity).slice(0, 4).map(
-                                (a, ix) =>
-                                    <Typography
-                                        key={ix}
-                                        variant="body1"
-                                        sx={{ fontSize: 12 }}
-                                    >
-                                         {a}...
-                                    </Typography>
-                            )
-                        }
-                </Box>
-            }
+                {
+                    (activity.size > 0) && 
+                    <Box
+                        sx={{
+                            position: 'absolute',
+                            bottom: '2rem',
+                            left: '2rem',
+                            zIndex: 999,
+                            m: 0,
+                            pt: '0.8rem',
+                            pb: '0.8rem',
+                            pl: '1.2rem',
+                            pr: '1.2rem',
+                            backgroundColor: 'rgba(255, 255, 255, 0.9)',
+                            color: 'secondary',
+                            border: '1px solid #c0c080',
+                        }}
+                    >
+                            {
+                                Array.from(activity).slice(0, 4).map(
+                                    (a, ix) =>
+                                        <Typography
+                                            key={ix}
+                                            variant="body1"
+                                            sx={{ fontSize: 12 }}
+                                        >
+                                             {a}...
+                                        </Typography>
+                                )
+                            }
+                    </Box>
+                }
                 <Banner/>
                 <Workspace/>
             </Box>

--- a/src/workbench/Workbench.tsx
+++ b/src/workbench/Workbench.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 
-import { Box, CircularProgress, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 
 import Banner from './Banner.tsx';
 import Workspace from './Workspace.tsx';

--- a/src/workbench/entity/EntityDetail.tsx
+++ b/src/workbench/entity/EntityDetail.tsx
@@ -13,6 +13,7 @@ import { useProgressStateStore } from '../state/ProgressState';
 
 import EntityHelp from './Help';
 import ElementNode from './ElementNode';
+import CenterSpinner from '../CenterSpinner';
 
 interface EntityDetailProps {
 }
@@ -33,7 +34,15 @@ const EntityDetail : React.FC <EntityDetailProps> = ({
     const setTool = useWorkbenchStateStore((state) => state.setTool);
 
     if (!selected) {
-        return ( <div>No node selected.</div> );
+        return (
+            <Box>
+                <CenterSpinner/>
+                <Typography variant="body1">
+                    No data to view.  Try Search to find data
+                    to explore.
+                </Typography>
+            </Box>
+        );
     }
 
     const [detail, setDetail] = useState<any>(undefined);
@@ -64,7 +73,15 @@ const EntityDetail : React.FC <EntityDetailProps> = ({
     }, [selected]);
 
     if (!detail)
-        return ( <div>No data.</div> );
+        return (
+            <Box>
+                <CenterSpinner/>
+                <Typography variant="body1">
+                    No data to view.  Try Search to find data
+                    to explore.
+                </Typography>
+            </Box>
+        );
 
     return (
         <>
@@ -72,6 +89,8 @@ const EntityDetail : React.FC <EntityDetailProps> = ({
             <Typography variant="h5" component="div" gutterBottom>
                 {selected.label}
             </Typography>
+
+            <CenterSpinner/>
 
             <Box sx={{mt:2,mb:2}}>
                 <Button
@@ -133,4 +152,5 @@ const EntityDetail : React.FC <EntityDetailProps> = ({
 }
 
 export default EntityDetail;
+
 

--- a/src/workbench/graph/GraphView.tsx
+++ b/src/workbench/graph/GraphView.tsx
@@ -16,6 +16,7 @@ import {
 } from '../state/knowledge-graph-viz';
 
 import GraphHelp from './Help';
+import CenterSpinner from '../CenterSpinner';
 
 interface GraphViewProps {
 }
@@ -39,7 +40,15 @@ const GraphView : React.FC <GraphViewProps> = ({
     const fgRef = useRef<any>();
 
     if (!selected) {
-        return ( <div>No node selected.</div> );
+        return (
+            <Box>
+                <CenterSpinner/>
+                <Typography variant="body1">
+                    No data to visualize.  Try Search to find data
+                    to explore.
+                </Typography>
+            </Box>
+        );
     }
 
     const [view, setView] = useState<any>(undefined);
@@ -68,7 +77,15 @@ const GraphView : React.FC <GraphViewProps> = ({
     }, [selected]);
 
     if (!view)
-        return ( <div>No data.</div> );
+        return (
+            <Box>
+                <CenterSpinner/>
+                <Typography variant="body1">
+                    No data to visualize.  Try Search to find data
+                    to explore.
+                </Typography>
+            </Box>
+        );
 
     const wrap = (s : string, w : number) => s.replace(
         new RegExp(`(?![^\\n]{1,${w}}$)([^\\n]{1,${w}})\\s`, 'g'), '$1\n'
@@ -99,18 +116,22 @@ const GraphView : React.FC <GraphViewProps> = ({
         <>
 
             <Box sx={{ display: "flex", alignItems: 'center', mt: 2}}>
-            <Typography variant="h5" component="div" sx={{m: 0, p: 0}}>
-                {selected.label}
-            </Typography>
 
-                        <IconButton
-                            aria-label="help"
-                            color="primary"
-                            size="large"
-                            onClick={() => setHelp(true)}
-                        >
-                            <Help fontSize="inherit"/>
-                        </IconButton>
+                <Typography variant="h5" component="div" sx={{m: 0, p: 0}}>
+                    {selected.label}
+                </Typography>
+
+                <CenterSpinner/>
+
+                <IconButton
+                    aria-label="help"
+                    color="primary"
+                    size="large"
+                    onClick={() => setHelp(true)}
+                >
+                    <Help fontSize="inherit"/>
+                </IconButton>
+
             </Box>
             <Box>
 

--- a/src/workbench/load/Load.tsx
+++ b/src/workbench/load/Load.tsx
@@ -12,6 +12,7 @@ import Keywords from './Keywords';
 import Operation from './Operation';
 import Content from './Content';
 import { useProgressStateStore } from '../state/ProgressState';
+import CenterSpinner from '../CenterSpinner';
 
 const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
 const RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label";
@@ -246,6 +247,8 @@ const Load : React.FC <LoadProps> = ({
                 submitFiles={submitFiles}
                 submitText={submitText}
             />
+
+            <CenterSpinner/>
 
         </>
 


### PR DESCRIPTION
- Remove center spinner to separate component
- Center spinner Only present on Explore, Vis and Load pages because the spinner exists on the button on Chat/Search.