### PR TITLE
Source panel scrollbar issues

### DIFF
--- a/src/components/chat/explainability/SourceDrawer.tsx
+++ b/src/components/chat/explainability/SourceDrawer.tsx
@@ -154,8 +154,6 @@ const SourceDrawer = ({ source, isOpen, onClose }: SourceDrawerProps) => {
                       bg="bg.subtle"
                       borderRadius="md"
                       p={3}
-                      maxH="400px"
-                      overflowY="auto"
                     >
                       <Text fontSize="sm" whiteSpace="pre-wrap">
                         {chunkText}


### PR DESCRIPTION
Removed maxH="400px" and overflowY="auto" from the source text box. The Drawer.Body already handles overflow scrolling, so the inner box was creating a redundant nested scrollbar.